### PR TITLE
Make the Smart Window quick action history button functional

### DIFF
--- a/browser/components/smartwindow/content/smartwindow.css
+++ b/browser/components/smartwindow/content/smartwindow.css
@@ -712,6 +712,11 @@ body {
   color: rgba(125, 32, 124, 0.8);
 }
 
+.quick-action-button:disabled {
+  opacity: 0.5;
+  pointer-events: none;
+}
+
 .quick-action-button:hover {
   transform: translateY(-2px);
   color: rgba(125, 32, 124, 1);

--- a/browser/components/smartwindow/content/smartwindow.html
+++ b/browser/components/smartwindow/content/smartwindow.html
@@ -114,7 +114,7 @@
             </svg>
             <span class="quick-action-text">History</span>
           </button>
-          <button class="quick-action-button" id="chats-button">
+          <button class="quick-action-button" id="chats-button" disabled>
             <svg
               class="quick-action-icon"
               width="24"
@@ -129,7 +129,7 @@
             </svg>
             <span class="quick-action-text">Chats</span>
           </button>
-          <button class="quick-action-button" id="downloads-button">
+          <button class="quick-action-button" id="downloads-button" disabled>
             <svg
               class="quick-action-icon"
               width="24"

--- a/browser/components/smartwindow/content/smartwindow.mjs
+++ b/browser/components/smartwindow/content/smartwindow.mjs
@@ -39,6 +39,7 @@ class SmartWindowPage {
     this.recentTabs = [];
     this.tabContextElements = {};
     this.currentTabPageText = "";
+    this.quickActionButtons = {};
 
     this.init();
   }
@@ -671,6 +672,7 @@ class SmartWindowPage {
     this.setupEventListeners();
 
     this.initializeTabContextUI();
+    this.initializeQuickActionButtons();
 
     this.initializeTabInfo();
     if (isSmartMode) {
@@ -1595,6 +1597,27 @@ class SmartWindowPage {
         this.smartbar.hideSuggestions();
       }
     }
+  }
+
+  setupQuickActionEventListeners() {
+    this.quickActionButtons.history?.addEventListener("click", e => {
+      e.stopPropagation();
+
+      const viewHandler = topChromeWindow?.FirefoxViewHandler
+      if (viewHandler) {
+        viewHandler.openTab("history");
+      } else {
+        console.warn("[SmartWindow] FirefoxViewHandler is not available.");
+      }
+    });
+  }
+
+  initializeQuickActionButtons() {
+    this.quickActionButtons = {
+      history: document.getElementById("history-button"),
+    };
+
+    this.setupQuickActionEventListeners();
   }
 }
 


### PR DESCRIPTION
Clicking the “History” quick action button on the Smart Window opens the FirefoxView history tab. Updates to the FirefoxView tabs “Chats” and “Downloads” are TBD so the quick action buttons are disabled for now.