### PR TITLE
Fix tab isolation for chat conversations

### DIFF
--- a/browser/components/smartwindow/content/smartwindow.mjs
+++ b/browser/components/smartwindow/content/smartwindow.mjs
@@ -565,28 +565,16 @@ class SmartWindowPage {
     }
   }
 
-  // Load chat messages for the current context (prioritize current tab)
+  // Load chat messages for the current context
   loadChatMessagesForCurrentContext() {
     if (this.chatBot) {
       let savedMessages = [];
 
-      // Try to load from current tab first
+      // Try to load from current tab
       if (this.lastTabInfo && this.isCurrentTabInContext()) {
         savedMessages = topChromeWindow.SmartWindow.getChatMessages(
           this.lastTabInfo.tabId
         );
-      }
-
-      // If no messages from current tab, try other tabs in context
-      if (savedMessages.length === 0) {
-        for (const tab of this.selectedTabContexts) {
-          savedMessages = topChromeWindow.SmartWindow.getChatMessages(
-            tab.tabId
-          );
-          if (savedMessages.length) {
-            break;
-          }
-        }
       }
 
       if (savedMessages.length) {


### PR DESCRIPTION
Removes fallback logic that loads chats from other open tabs when the current tab has no chat history. This was causing the bug where selecting multiple tabs for context would display chat messages from other tabs.