### PR TITLE
Adds highlights and titles to Smart Window suggestions

### DIFF
--- a/browser/components/smartwindow/content/mentions.mjs
+++ b/browser/components/smartwindow/content/mentions.mjs
@@ -55,6 +55,15 @@ export class MentionDropdown {
 
     let itemIndex = 0;
 
+    // Show empty state
+    if (this.items.length === 0) {
+      const emptyState = document.createElement("div");
+      emptyState.className = "mention-section-header";
+      emptyState.textContent = "No tabs or pages found";
+      this.element.appendChild(emptyState);
+      return;
+    }
+
     // Render tabs section
     if (tabs.length) {
       const tabHeader = document.createElement("div");

--- a/browser/components/smartwindow/content/smartbar.mjs
+++ b/browser/components/smartwindow/content/smartbar.mjs
@@ -243,6 +243,34 @@ export function attachToElement(element, options = {}) {
     },
   });
 
+  function highlightQueryMatches(element, query) {
+    if (!query || !element.textContent) {
+      return;
+    }
+
+    const text = element.textContent;
+    // Split query into words and escape special chars
+    const words = query
+      .split(/\s+/)
+      .map(w => w.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
+
+    if (words.length === 0) {
+      return;
+    }
+
+    // Highlight matched words
+    const regex = new RegExp(`(${words.join("|")})`, "gi");
+
+    // Split and rebuild nodes
+    element.textContent = "";
+    for (const part of text.split(regex)) {
+      const node = regex.test(part)
+        ? Object.assign(document.createElement("mark"), { textContent: part })
+        : document.createTextNode(part);
+      element.appendChild(node);
+    }
+  }
+
   // Suggestion management functions
   function createSuggestionButton(suggestion, index) {
     const button = document.createElement("button");
@@ -255,12 +283,43 @@ export function attachToElement(element, options = {}) {
       ? getQueryTypeIcon(suggestion.type)
       : "🔍";
 
-    const text = document.createElement("span");
-    text.className = "suggestion-text";
-    text.textContent = suggestion.text;
+    const textContainer = document.createElement("div");
+    textContainer.className = "suggestion-text-container";
+
+    // For matches of type navigate: Show title and URL
+    if (suggestion.type === "navigate" && suggestion.title) {
+      const title = document.createElement("span");
+      title.className = "suggestion-title";
+      title.textContent = suggestion.title;
+
+      const url = document.createElement("span");
+      url.className = "suggestion-url";
+      url.textContent = suggestion.text || suggestion.url;
+
+      // Highlight matches if query is provided
+      if (suggestion.query) {
+        highlightQueryMatches(title, suggestion.query);
+        highlightQueryMatches(url, suggestion.query);
+      }
+
+      textContainer.appendChild(title);
+      textContainer.appendChild(url);
+    } else {
+      // For other suggestion types: Use the original text
+      const text = document.createElement("span");
+      text.className = "suggestion-text";
+      text.textContent = suggestion.text;
+
+      // Highlight matches if query is provided
+      if (suggestion.query) {
+        highlightQueryMatches(text, suggestion.query);
+      }
+
+      textContainer.appendChild(text);
+    }
 
     button.appendChild(icon);
-    button.appendChild(text);
+    button.appendChild(textContainer);
 
     // Add event listeners
     button.addEventListener("mouseenter", () => {
@@ -294,7 +353,8 @@ export function attachToElement(element, options = {}) {
   function showSuggestions(
     suggestions,
     title = "Suggestions:",
-    isQuickPrompts = false
+    isQuickPrompts = false,
+    query = "",
   ) {
     if (!suggestionsContainer) {
       return;
@@ -336,7 +396,8 @@ export function attachToElement(element, options = {}) {
     suggestionsList.innerHTML = "";
 
     suggestions.forEach((suggestion, index) => {
-      const suggestionButton = createSuggestionButton(suggestion, index);
+      const suggestionWithQuery = { ...suggestion, query };
+      const suggestionButton = createSuggestionButton(suggestionWithQuery, index);
       suggestionsList.appendChild(suggestionButton);
     });
   }

--- a/browser/components/smartwindow/content/smartwindow.css
+++ b/browser/components/smartwindow/content/smartwindow.css
@@ -480,6 +480,25 @@ body {
   white-space: nowrap;
 }
 
+.suggestion-text-container mark,
+.suggestion-text mark {
+  background: none;
+  font-weight: var(--font-weight-bold);
+}
+
+
+.suggestion-url::before {
+  content: "—";
+  color: #333;
+  padding: 0 var(--space-xsmall);
+}
+
+.suggestion-url,
+.suggestion-url mark {
+  color: #0066cc;
+  font-size: 12px;
+}
+
 /* Hide quick prompts (not actual suggestions) when not in bottom chat mode and user has typed something */
 :root:not(.chat-mode-bottom) .smart-window-container .suggestions-container.quick-prompts.user-edited {
   display: none;

--- a/browser/components/smartwindow/content/smartwindow.mjs
+++ b/browser/components/smartwindow/content/smartwindow.mjs
@@ -1330,6 +1330,7 @@ class SmartWindowPage {
         for (const result of resultsToProcess) {
           const detectedType = await this.getEffectiveQueryType(result.text);
           suggestions.push({
+            title: result.title,
             text: result.text,
             type: detectedType,
           });
@@ -1341,6 +1342,7 @@ class SmartWindowPage {
         s => s.type === "navigate"
       );
       const navigateSuggestions = navigateResults.slice(0, 2).map(s => ({
+        title: s.title,
         text: s.text,
         type: s.type,
       }));
@@ -1349,6 +1351,7 @@ class SmartWindowPage {
       // Add action results as-is
       const actionResults = urlbarSuggestions.filter(s => s.type === "action");
       const actionSuggestions = actionResults.slice(0, 2).map(s => ({
+        title: s.title,
         text: s.text,
         type: s.type,
       }));
@@ -1384,7 +1387,12 @@ class SmartWindowPage {
       }
 
       if (this.smartbar) {
-        this.smartbar.showSuggestions(suggestions.slice(0, 10), "Suggestions:");
+        this.smartbar.showSuggestions(
+          suggestions.slice(0, 10),
+          "Suggestions:",
+          false,
+          query,
+        );
       }
     } catch (error) {
       console.error("Error getting live suggestions:", error);
@@ -1400,7 +1408,12 @@ class SmartWindowPage {
       );
 
       if (this.smartbar) {
-        this.smartbar.showSuggestions(suggestions, "Suggestions:");
+        this.smartbar.showSuggestions(
+          suggestions,
+          "Suggestions:",
+          false,
+          query,
+        );
       }
     }
   }


### PR DESCRIPTION
- Highlights query matches in the list of suggested items
- Adds titles for items of type `navigate`
- Show preliminary empty state if there are no `tabs` or `history` items available to `@mention`

| Before | After |
| --- | --- |
| <img width="720" height="521" alt="image" src="https://github.com/user-attachments/assets/e289ff1d-c9ea-49c9-9852-56da8ccb7053" /> | <img width="720" height="511" alt="image" src="https://github.com/user-attachments/assets/130ead1b-14c3-449a-a427-0e582aa0cc70" /> |
