### PR TITLE
Clear query input after getting the effective query type

### DIFF
--- a/browser/components/smartwindow/content/smartwindow.mjs
+++ b/browser/components/smartwindow/content/smartwindow.mjs
@@ -1325,15 +1325,15 @@ class SmartWindowPage {
     const textFromBar = this.smartbar?.getText?.() || "";
     const htmlFromBar = this.smartbar?.getHTML?.() || null;
 
+    document.documentElement.setAttribute("haschat", "true");
+
+    const type = await this.getEffectiveQueryType(query);
+
     // Hide suggestions after selection
     if (this.smartbar) {
       this.smartbar.clear();
       this.smartbar.hideSuggestions();
     }
-
-    document.documentElement.setAttribute("haschat", "true");
-
-    const type = await this.getEffectiveQueryType(query);
 
     // Handle chat queries with chatbot component in different modes
     if (type === "chat") {


### PR DESCRIPTION
Don’t clear the query input before calling `getEffectiveQueryType`.