### PR TITLE
Update entrypoint and service to aimode in FxA auth flow

### DIFF
--- a/browser/base/content/browser-smart-window.js
+++ b/browser/base/content/browser-smart-window.js
@@ -128,6 +128,9 @@ var SmartWindow = {
                       type: "FXA_SMART_WINDOW_SIGNIN_FLOW",
                       data: {
                         entrypoint: "aimode",
+                        extraParams: {
+                          service: "aimode",
+                        }
                       },
                     },
                     gBrowser.selectedBrowser

--- a/browser/components/smartwindow/content/utils.mjs
+++ b/browser/components/smartwindow/content/utils.mjs
@@ -14,6 +14,11 @@ ChromeUtils.defineESModuleGetters(lazy, {
 
 import { createEngine } from "chrome://global/content/ml/EngineProcess.sys.mjs";
 import { SmartAssistEngine } from "moz-src:///browser/components/genai/SmartAssistEngine.sys.mjs";
+import { getFxAccountsSingleton } from "resource://gre/modules/FxAccounts.sys.mjs";
+import {
+  SCOPE_PROFILE,
+  OAUTH_CLIENT_ID,
+} from "resource://gre/modules/FxAccountsCommon.sys.mjs";
 
 const { ChatHistoryMessage } = ChromeUtils.importESModule(
   "resource:///modules/smartwindow/ChatHistory.sys.mjs"
@@ -382,6 +387,20 @@ const get_page_content = async ({ url, mode, page }, allowedUrls) => {
   }
 };
 
+const getFxAccountToken = async () => {
+  try {
+    const fxAccounts = getFxAccountsSingleton();
+    const token = await fxAccounts.getOAuthToken({
+      scope: SCOPE_PROFILE,
+      client_id: OAUTH_CLIENT_ID,
+    });
+    return token;
+  } catch (error) {
+    console.warn("Failed to obtain a valid FxA token:", error);
+    return null;
+  }
+};
+
 /**
  * @param {PageExtractor} pageExtractor
  * @param {string} mode
@@ -459,6 +478,7 @@ async function runExtraction(pageExtractor, mode, page, label) {
  */
 export async function* fetchWithHistory(messages, allowedUrls) {
   const engineInstance = await createOpenAIEngine();
+  const fxAccountToken = await getFxAccountToken();
 
   // Normalize roles to lowercase and handle system messages
   let convo = Array.isArray(messages)
@@ -512,6 +532,7 @@ export async function* fetchWithHistory(messages, allowedUrls) {
   const streamModelResponse = () =>
     engineInstance.runWithGenerator({
       streamOptions: { enabled: true },
+      fxAccountToken,
       tool_choice: "auto",
       tools: toolsConfig,
       args: convo,

--- a/browser/components/smartwindow/content/welcome.js
+++ b/browser/components/smartwindow/content/welcome.js
@@ -69,6 +69,9 @@ XPCOMUtils.defineLazyPreferenceGetter(
                   {
                     data: {
                       entrypoint: "aimode",
+                      extraParams: {
+                        service: "aimode",
+                      }
                     },
                     type: "FXA_SMART_WINDOW_SIGNIN_FLOW",
                     navigate: true,

--- a/toolkit/components/ml/content/backends/OpenAIPipeline.mjs
+++ b/toolkit/components/ml/content/backends/OpenAIPipeline.mjs
@@ -327,10 +327,19 @@ export class OpenAIPipeline {
     lazy.console.debug("Running OpenAI pipeline");
     try {
       const { baseURL, apiKey, modelId } = this.#options;
+      let fxAccountToken = request.fxAccountToken
+        ? request.fxAccountToken
+        : null;
+
+      const defaultHeaders = fxAccountToken
+        ? { "authorization": `Bearer ${fxAccountToken}` }
+        : undefined;
+
       const client = new OpenAIPipeline.OpenAILib.OpenAI({
         baseURL: baseURL ? baseURL : "http://localhost:11434/v1",
         apiKey: apiKey || "ollama",
         maxRetries: 10,
+        ...(defaultHeaders ? { defaultHeaders } : {}),
       });
       const stream = request.streamOptions?.enabled || false;
       const tools = request.tools || [];


### PR DESCRIPTION
Test step to use MLPA proxy server without API key 

 1. Set FxA server as stage by setting pref `identity.fxaccounts.autoconfig.uri` as `https://accounts.stage.mozaws.net`
 2. Set pref `browser.smartwindow.requireSignIn` as true . 
 3. Set Smart Window `endpoint` as https://mlpa-dev.llm-proxy.nonprod.dataservices.mozgcp.net/v1/ and `model` as `mistral-small-2503` and leave  key pref empty
 4. Click Switch to Smart Window and complete authentication flow. Please note your production FxA account will not work (though you can use same email address) and need to create an account on stage.
 5. If prompted for API key , you can enter any text and continue

Noticed below edge case sometime
 6. After successful authentication on staging server user is not redirected to Smart window and lands on account settings web page. If that happens restart build and try again to authenticate by clicking on 'Switch to Smart Window'