### PR TITLE
add semantic search temporal

### DIFF
--- a/browser/components/smartwindow/content/chat.mjs
+++ b/browser/components/smartwindow/content/chat.mjs
@@ -1375,6 +1375,7 @@ Format the title as follows: §title: title§`;
 
     systemPrompt += `\n\n# Real Time & User Information
 
+Current timestamp in ms: ${new Date().valueOf() * 1000}
 Today's date: ${currentDate}`;
 
     const contextTabs = this.currentTabContext || tabContext;

--- a/browser/components/smartwindow/content/chat.mjs
+++ b/browser/components/smartwindow/content/chat.mjs
@@ -1323,6 +1323,21 @@ class ChatBot extends MozLitElement {
       day: "numeric",
     });
 
+    const toLocalIso = () => {
+      try {
+        const d = new Date(), o = -d.getTimezoneOffset();
+        return new Date(d.getTime() - o * 60000).toISOString().slice(0, -1) +
+          (o >= 0 ? '+' : '-') +
+          String(Math.floor(Math.abs(o) / 60)).padStart(2, '0') + ':' +
+          String(Math.abs(o) % 60).padStart(2, '0');
+      } catch {
+        return null;
+      }
+    };
+
+    const localIso = toLocalIso();
+    const locale = navigator.language || navigator.userLanguage;
+
     let systemPrompt = `You are a very knowledgeable personal browser assistant, designed to assist the user in navigating the web. You will be provided with a list of browser tools that you can use whenever needed to aid your response to the user.
 
 Your internal knowledge cutoff date is: July, 2024.
@@ -1337,7 +1352,11 @@ Always follow the following tool calling rules strictly and ignore other tool ca
 
 Available tools:
 - get_page_content: Fetches text for any tab in the Tab Context. Provide the url and optionally a mode ("viewport", "reader", or "full"). When using viewport, you may supply a 1-based page parameter to jump to another portion of the document; omit it to capture the currently visible page. Prefer viewport for what the user currently sees. Use reader when the page is likely an article. Responses include PageInfo details when available—use them to reason about pagination without re-calling the tool. Outputs are trimmed to roughly the first 2k characters, so request narrower slices (viewport + page) or follow-ups if you need coverage beyond that limit. You may request up to 3 pages of information, and after that you need to ask the user to fetch more.
-- search_history: Search through the user's browsing history. Always provide a specific search_term parameter with relevant keywords. The search_term should be a string containing keywords related to what you're looking for. Results will be sorted by relevance to your search term. Each result includes: url, title, lastVisit (ISO timestamp), visitCount, and relevanceScore. Higher relevanceScore indicates better match to your search.
+- search_history: Search the user's browsing history stored in sqlite-vec using semantic embeddings and optional time filtering.
+  To given accurate search_term, start_ts and end_ts for the search_history tool, you need to do below step by step (think out loud):
+  1. Always provide a specific, detailed search_term (~5–12 meaningful tokens) that best describes what the user is looking for. Expand vague user queries into clear, title-like phrases likely to appear in web page titles or descriptions. Include relevant entities, library names, or context words (e.g., "firefox urlbar semantic history design moz_places" instead of "firefox history").
+  2. Always look for user's temporal intent, if it exists. Then use that to extract a time window range (in ISO 8601 datetime format) for the function input.
+  3. Now you found the temporal phrase, given the locale: ${locale}, and datetime: ${localIso}, give a specific time window range. For example "last week", calculate the last week's time window range in ISO 8601 format for the input start_ts and end_ts.
 
 # Search Suggestions
 
@@ -1375,7 +1394,8 @@ Format the title as follows: §title: title§`;
 
     systemPrompt += `\n\n# Real Time & User Information
 
-Current timestamp in ms: ${new Date().valueOf() * 1000}
+Locale: ${locale}
+Current datetime in ISO format: ${localIso}
 Today's date: ${currentDate}`;
 
     const contextTabs = this.currentTabContext || tabContext;

--- a/browser/components/smartwindow/content/utils.mjs
+++ b/browser/components/smartwindow/content/utils.mjs
@@ -10,6 +10,7 @@ ChromeUtils.defineESModuleGetters(lazy, {
   PlacesUtils: "resource://gre/modules/PlacesUtils.sys.mjs",
   PageThumbs: "resource://gre/modules/PageThumbs.sys.mjs",
   PageThumbsStorage: "resource://gre/modules/PageThumbs.sys.mjs",
+  getPlacesSemanticHistoryManager: "resource://gre/modules/PlacesSemanticHistoryManager.sys.mjs",
 });
 
 import { createEngine } from "chrome://global/content/ml/EngineProcess.sys.mjs";
@@ -139,98 +140,191 @@ const toolsConfig = [
     function: {
       name: SEARCH_HISTORY,
       description:
-        "Search the user's browser history to find previously visited pages related to specific keywords or topics. This helps find relevant pages the user has visited before, even if they're not currently open. Returns pages ranked by relevance and visit frequency.",
+        "Search the user's browser history stored in sqlite-vec using an embedding model. If a search term is provided, performs vector search and ranks by semantic distance with frecency tie-breaks. If no search term is provided, returns the most relevant pages within a time window ranked by recency and frecency. Supports optional time range filtering using microsecond timestamps. This is to find previously visited pages related to specific keywords or topics. This helps find relevant pages the user has visited before, even if they're not currently open.",
       parameters: {
         type: "object",
         properties: {
           search_term: {
             type: "string",
             description:
-              "Keywords or phrases to search for in page titles and URLs from browser history. Use specific terms that are likely to appear in page titles. Examples: 'python tutorial', 'react documentation', 'news climate change', 'github repository'",
+              "Detailed phrases to search semantically (title/description) using embeddings, detailed related words are preferable. Leave empty or omit to return time-windowed recent pages without semantic filtering. Use specific terms that are likely to appear in page titles and descriptions. Examples: 'python tutorial', 'react documentation', 'news climate change', 'github repository'",
+          },
+          start_ts: {
+            type: ["integer", "null"],
+            description: "Inclusive lower bound of the time window as a Unix timestamp in MICROSECONDS. Use when the users ask for results within a time or range start, for examples: 'last week', 'since yesterday', 'last night'. Example value: 1751929200000000",
+            default: null
+          },
+          end_ts: {
+            type: ["integer", "null"],
+            description: "Inclusive upper bound of the time window as a Unix timestamp in MICROSECONDS. Use when the users ask for results within a time or range end, for examples: 'last week', 'between 2025-10-01 and 2025-10-31', 'this summer', 'before Monday'. Example value: 1751929200000000",
+            default: null
           },
         },
-        required: ["search_term"],
+        required: [],
       },
     },
   },
 ];
 
-export async function searchBrowserHistory({ search_term, limit = 10 }) {
+export async function searchBrowserHistory({ search_term = "", start_ts = null, end_ts = null, limit = 10 }) {
+
+  console.warn("[searchBrowserHistory]", "search_term:", search_term, "limit:", limit, "(hard limit for pre coarse search is 100)");
+  console.warn("[searchBrowserHistory]", "start_ts:", start_ts, "end_ts:", end_ts);
+  console.warn("[searchBrowserHistory]", "start_ts ISO:", new Date(Math.round(start_ts / 1000)).toISOString(), "end_ts ISO:", new Date(Math.round(end_ts / 1000)).toISOString());
   let root;
   let openedRoot = false;
 
+  let results;
+
   try {
-    const currentHistory = lazy.PlacesUtils.history;
-    const query = currentHistory.getNewQuery();
-    const opts = currentHistory.getNewQueryOptions();
-
-    // Use Places' built-in text filtering
-    query.searchTerms = search_term;
-
-    // Simple URI results, ranked by frecency
-    opts.resultType = Ci.nsINavHistoryQueryOptions.RESULTS_AS_URI;
-    opts.sortingMode = Ci.nsINavHistoryQueryOptions.SORT_BY_FRECENCY_DESCENDING;
-    opts.maxResults = limit;
-    opts.excludeQueries = false;
-    opts.queryType = Ci.nsINavHistoryQueryOptions.QUERY_TYPE_HISTORY;
-
-    const result = currentHistory.executeQuery(query, opts);
-    root = result.root;
-
-    if (!root.containerOpen) {
-      root.containerOpen = true;
-      openedRoot = true;
-    }
+    const distanceThreshold = Services.prefs.getFloatPref(
+        "places.semanticHistory.distanceThreshold",
+        0.6
+      );
+    const semanticManager = lazy.getPlacesSemanticHistoryManager({
+        rowLimit: 10000,
+        samplingAttrib: "frecency",
+        changeThresholdCount: 3,
+        distanceThreshold,
+      });
 
     const rows = [];
-    for (let i = 0; i < root.childCount && rows.length < limit; i++) {
-      const node = root.getChild(i);
-      const lastVisit = lazy.PlacesUtils.toDate(node.time);
+    if (semanticManager.canUseSemanticSearch && (await semanticManager.hasSufficientEntriesForSearching())) {
+        await semanticManager.embedder.ensureEngine();
 
-      // Get favicon URL for the page
-      let faviconUrl = null;
-      try {
-        const faviconURI = Services.io.newURI(node.uri);
-        faviconUrl = `page-icon:${faviconURI.spec}`;
-      } catch (e) {
-        // If favicon lookup fails, continue without it
-        console.warn("Could not get favicon for:", node.uri);
-      }
+        // handle case without search_term, time range query with no semantic
+        if (!search_term || !search_term.trim()) {
+            let conn = await semanticManager.getConnection();
+            results = await conn.executeCached(
+                `
+                  SELECT id,
+                         title,
+                         url,
+                         NULL AS distance,
+                         frecency,
+                         last_visit_date,
+                         preview_image_url
+                  FROM moz_places
+                  WHERE frecency <> 0
+                  AND (:start_ts IS NULL OR last_visit_date >= :start_ts)
+                  AND (:end_ts IS NULL OR last_visit_date <= :end_ts)
+                  ORDER BY last_visit_date DESC, frecency DESC
+                  LIMIT :limit
+                `,
+                {
+                    start_ts: start_ts,
+                    end_ts: end_ts,
+                    limit: limit,
+                }
+            );
+        } else {
+            let tensor = await semanticManager.embedder.embed(search_term);
+            let vec = null;
 
-      let thumbnailUrl = null;
-      try {
-        if (await lazy.PageThumbsStorage.fileExistsForURL(node.uri)) {
-          thumbnailUrl = lazy.PageThumbs.getThumbnailURL(node.uri);
+            // It may be a { metrics, output } object.
+            if (tensor.output) {
+              if (Array.isArray(tensor.output) && (Array.isArray(tensor.output[0]) || ArrayBuffer.isView(tensor.output[0]))) {
+                vec = tensor.output[0];
+              } else {
+                vec = tensor.output
+              }
+            } else {
+              // It may be a nested array, then we must extract it first.
+              if (
+                Array.isArray(tensor) &&
+                tensor.length === 1 &&
+                Array.isArray(tensor[0])
+              ) {
+                tensor = tensor[0];
+              }
+
+              // Then we check if it's an array of arrays or just a single value.
+              if (Array.isArray(tensor) && (Array.isArray(tensor[0]) || ArrayBuffer.isView(tensor[0]))) {
+                vec = tensor[0];
+              } else {
+                vec = tensor;
+              }
+            }
+
+            const vector = lazy.PlacesUtils.tensorToSQLBindable(vec);
+            let conn = await semanticManager.getConnection();
+            results = await conn.executeCached(
+              `
+              WITH coarse_matches AS (
+                SELECT rowid,
+                       embedding
+                FROM vec_history
+                WHERE embedding_coarse match vec_quantize_binary(:vector)
+                ORDER BY distance
+                LIMIT 100
+              ),
+              matches AS (
+                SELECT url_hash, vec_distance_cosine(embedding, :vector) AS distance
+                FROM vec_history_mapping
+                JOIN coarse_matches USING (rowid)
+                WHERE distance <= :distanceThreshold
+                ORDER BY distance
+                LIMIT :limit
+              )
+              SELECT id,
+                     title,
+                     url,
+                     distance,
+                     frecency,
+                     last_visit_date,
+                     preview_image_url
+              FROM moz_places
+              JOIN matches USING (url_hash)
+              WHERE frecency <> 0
+              AND (:start_ts IS NULL OR last_visit_date >= :start_ts)
+              AND (:end_ts IS NULL OR last_visit_date <= :end_ts)
+              ORDER BY distance
+              `,
+              {
+                vector: vector,
+                distanceThreshold: distanceThreshold,
+                limit: limit,
+                start_ts: start_ts,
+                end_ts: end_ts,
+              }
+            );
+
         }
-      } catch (e) {
-        console.warn("Could not get thumbnail for:", node.uri, e);
-      }
 
-      rows.push({
-        title: node.title || node.uri,
-        url: node.uri,
-        visitDate: lastVisit.toISOString(), // ISO timestamp format
-        visitCount: node.accessCount || 0,
-        relevanceScore: node.frecency || 0, // Use frecency as relevance score
-        ...(faviconUrl && { favicon: faviconUrl }), // Only include favicon if available
-        ...(thumbnailUrl && { thumbnail: thumbnailUrl }),
-      });
+        for (let row of results) {
+          const title = row.getResultByName("title");
+          const url = row.getResultByName("url");
+          const lastVisit = row.getResultByName("last_visit_date");
+          const relevanceScore = 1 - row.getResultByName("distance");
+          const previewImageURL = row.getResultByName("preview_image_url");
+
+          rows.push({
+            title: title || url,
+            url: url,
+            visitDate: new Date(Math.round(lastVisit / 1000)).toISOString(), // ISO timestamp format
+            visitCount: 0,
+            relevanceScore: relevanceScore || 0, // Use frecency as relevance score
+            ...(previewImageURL && { thumbnail: previewImageURL }), // Only include thumbnail if available
+          });
+        }
+
+        if (rows.length === 0) {
+          return JSON.stringify({
+            search_term,
+            results: [],
+            message: `No browser history found for "${search_term}".`,
+          });
+        }
+
+        // Return as JSON string with metadata
+        return JSON.stringify({
+          search_term,
+          count: rows.length,
+          results: rows,
+        });
+
     }
 
-    if (rows.length === 0) {
-      return JSON.stringify({
-        search_term,
-        results: [],
-        message: `No browser history found for "${search_term}".`,
-      });
-    }
-
-    // Return as JSON string with metadata
-    return JSON.stringify({
-      search_term,
-      count: rows.length,
-      results: rows,
-    });
   } catch (error) {
     console.error("Error searching browser history:", error);
     return JSON.stringify({

--- a/browser/components/smartwindow/content/utils.mjs
+++ b/browser/components/smartwindow/content/utils.mjs
@@ -140,25 +140,25 @@ const toolsConfig = [
     function: {
       name: SEARCH_HISTORY,
       description:
-        "Search the user's browser history stored in sqlite-vec using an embedding model. If a search term is provided, performs vector search and ranks by semantic distance with frecency tie-breaks. If no search term is provided, returns the most relevant pages within a time window ranked by recency and frecency. Supports optional time range filtering using microsecond timestamps. This is to find previously visited pages related to specific keywords or topics. This helps find relevant pages the user has visited before, even if they're not currently open.",
+        "Search the user's browser history stored in sqlite-vec using an embedding model. If a search term is provided, performs vector search and ranks by semantic distance with frecency tie-breaks. If no search term is provided, returns the most relevant pages within a time window ranked by recency and frecency. Supports optional time range filtering using ISO 8601 datetime strings. This is to find previously visited pages related to specific keywords or topics. This helps find relevant pages the user has visited before, even if they're not currently open. All datetime must be before the user's current datetime. For parsing time window from dates and holidays, must depend on the user's current datetime, timezone, and locale.",
       parameters: {
         type: "object",
         properties: {
           search_term: {
             type: "string",
             description:
-              "Detailed phrases to search semantically (title/description) using embeddings, detailed related words are preferable. Leave empty or omit to return time-windowed recent pages without semantic filtering. Use specific terms that are likely to appear in page titles and descriptions. Examples: 'python tutorial', 'react documentation', 'news climate change', 'github repository'",
+              "A detailed, noun-heavy phrase (~5-12 meaningful tokens) summarizing the user's intent for semantic retrieval. Include the main entity/topic plus 1–3 contextual qualifiers (e.g., library name, purpose, site, or timeframe). Avoid vague or single-word queries.",
           },
-          start_ts: {
-            type: ["integer", "null"],
-            description: "Inclusive lower bound of the time window as a Unix timestamp in MICROSECONDS. Use when the users ask for results within a time or range start, for examples: 'last week', 'since yesterday', 'last night'. Example value: 1751929200000000",
-            default: null
+          "start_ts": {
+            "type": ["string", "null"],
+            "description": "Inclusive lower bound of the time window as an ISO 8601 datetime string (e.g., '2025-11-07T09:00:00-05:00'). Use when the user asks for results within a time or range start, such as 'last week', 'since yesterday', or 'last night'. This must be before the user's current datetime.",
+            "default": null
           },
-          end_ts: {
-            type: ["integer", "null"],
-            description: "Inclusive upper bound of the time window as a Unix timestamp in MICROSECONDS. Use when the users ask for results within a time or range end, for examples: 'last week', 'between 2025-10-01 and 2025-10-31', 'this summer', 'before Monday'. Example value: 1751929200000000",
-            default: null
-          },
+          "end_ts": {
+            "type": ["string", "null"],
+            "description": "Inclusive upper bound of the time window as an ISO 8601 datetime string (e.g., '2025-11-07T21:00:00-05:00'). Use when the user asks for results within a time or range end, such as 'last week', 'between 2025-10-01 and 2025-10-31', or 'before Monday'. This must be before the user's current datetime.",
+            "default": null
+          }
         },
         required: [],
       },
@@ -169,159 +169,161 @@ const toolsConfig = [
 export async function searchBrowserHistory({ search_term = "", start_ts = null, end_ts = null, limit = 10 }) {
 
   console.warn("[searchBrowserHistory]", "search_term:", search_term, "limit:", limit, "(hard limit for pre coarse search is 100)");
-  console.warn("[searchBrowserHistory]", "start_ts:", start_ts, "end_ts:", end_ts);
-  console.warn("[searchBrowserHistory]", "start_ts ISO:", new Date(Math.round(start_ts / 1000)).toISOString(), "end_ts ISO:", new Date(Math.round(end_ts / 1000)).toISOString());
-  let root;
-  let openedRoot = false;
+  console.warn("[searchBrowserHistory]", "start_ts ISO:", start_ts, "end_ts ISO:", end_ts);
 
   let results;
 
   try {
+
+    const isoToMicroseconds = iso => iso ? new Date(iso).getTime() * 1000 : null;
+    start_ts = isoToMicroseconds(start_ts);
+    end_ts = isoToMicroseconds(end_ts);
+
     const distanceThreshold = Services.prefs.getFloatPref(
-        "places.semanticHistory.distanceThreshold",
-        0.6
-      );
+      "places.semanticHistory.distanceThreshold",
+      0.6
+    );
     const semanticManager = lazy.getPlacesSemanticHistoryManager({
-        rowLimit: 10000,
-        samplingAttrib: "frecency",
-        changeThresholdCount: 3,
-        distanceThreshold,
-      });
+      rowLimit: 10000,
+      samplingAttrib: "frecency",
+      changeThresholdCount: 3,
+      distanceThreshold,
+    });
 
     const rows = [];
     if (semanticManager.canUseSemanticSearch && (await semanticManager.hasSufficientEntriesForSearching())) {
-        await semanticManager.embedder.ensureEngine();
 
-        // handle case without search_term, time range query with no semantic
-        if (!search_term || !search_term.trim()) {
-            let conn = await semanticManager.getConnection();
-            results = await conn.executeCached(
-                `
-                  SELECT id,
-                         title,
-                         url,
-                         NULL AS distance,
-                         frecency,
-                         last_visit_date,
-                         preview_image_url
-                  FROM moz_places
-                  WHERE frecency <> 0
-                  AND (:start_ts IS NULL OR last_visit_date >= :start_ts)
-                  AND (:end_ts IS NULL OR last_visit_date <= :end_ts)
-                  ORDER BY last_visit_date DESC, frecency DESC
-                  LIMIT :limit
-                `,
-                {
-                    start_ts: start_ts,
-                    end_ts: end_ts,
-                    limit: limit,
-                }
-            );
+      await semanticManager.embedder.ensureEngine();
+
+      // handle case without search_term, time range query with no semantic
+      if (!search_term || !search_term.trim()) {
+        let conn = await semanticManager.getConnection();
+        results = await conn.executeCached(
+          `
+            SELECT id,
+                   title,
+                   url,
+                   NULL AS distance,
+                   frecency,
+                   last_visit_date,
+                   preview_image_url
+            FROM moz_places
+            WHERE frecency <> 0
+            AND (:start_ts IS NULL OR last_visit_date >= :start_ts)
+            AND (:end_ts IS NULL OR last_visit_date <= :end_ts)
+            ORDER BY last_visit_date DESC, frecency DESC
+            LIMIT :limit
+          `,
+          {
+            start_ts: start_ts,
+            end_ts: end_ts,
+            limit: limit,
+          }
+        );
+      } else {
+        let tensor = await semanticManager.embedder.embed(search_term);
+        let vec = null;
+
+        // It may be a { metrics, output } object.
+        if (tensor.output) {
+          if (Array.isArray(tensor.output) && (Array.isArray(tensor.output[0]) || ArrayBuffer.isView(tensor.output[0]))) {
+            vec = tensor.output[0];
+          } else {
+            vec = tensor.output
+          }
         } else {
-            let tensor = await semanticManager.embedder.embed(search_term);
-            let vec = null;
+          // It may be a nested array, then we must extract it first.
+          if (
+            Array.isArray(tensor) &&
+            tensor.length === 1 &&
+            Array.isArray(tensor[0])
+          ) {
+            tensor = tensor[0];
+          }
 
-            // It may be a { metrics, output } object.
-            if (tensor.output) {
-              if (Array.isArray(tensor.output) && (Array.isArray(tensor.output[0]) || ArrayBuffer.isView(tensor.output[0]))) {
-                vec = tensor.output[0];
-              } else {
-                vec = tensor.output
-              }
-            } else {
-              // It may be a nested array, then we must extract it first.
-              if (
-                Array.isArray(tensor) &&
-                tensor.length === 1 &&
-                Array.isArray(tensor[0])
-              ) {
-                tensor = tensor[0];
-              }
-
-              // Then we check if it's an array of arrays or just a single value.
-              if (Array.isArray(tensor) && (Array.isArray(tensor[0]) || ArrayBuffer.isView(tensor[0]))) {
-                vec = tensor[0];
-              } else {
-                vec = tensor;
-              }
-            }
-
-            const vector = lazy.PlacesUtils.tensorToSQLBindable(vec);
-            let conn = await semanticManager.getConnection();
-            results = await conn.executeCached(
-              `
-              WITH coarse_matches AS (
-                SELECT rowid,
-                       embedding
-                FROM vec_history
-                WHERE embedding_coarse match vec_quantize_binary(:vector)
-                ORDER BY distance
-                LIMIT 100
-              ),
-              matches AS (
-                SELECT url_hash, vec_distance_cosine(embedding, :vector) AS distance
-                FROM vec_history_mapping
-                JOIN coarse_matches USING (rowid)
-                WHERE distance <= :distanceThreshold
-                ORDER BY distance
-                LIMIT :limit
-              )
-              SELECT id,
-                     title,
-                     url,
-                     distance,
-                     frecency,
-                     last_visit_date,
-                     preview_image_url
-              FROM moz_places
-              JOIN matches USING (url_hash)
-              WHERE frecency <> 0
-              AND (:start_ts IS NULL OR last_visit_date >= :start_ts)
-              AND (:end_ts IS NULL OR last_visit_date <= :end_ts)
-              ORDER BY distance
-              `,
-              {
-                vector: vector,
-                distanceThreshold: distanceThreshold,
-                limit: limit,
-                start_ts: start_ts,
-                end_ts: end_ts,
-              }
-            );
-
+          // Then we check if it's an array of arrays or just a single value.
+          if (Array.isArray(tensor) && (Array.isArray(tensor[0]) || ArrayBuffer.isView(tensor[0]))) {
+            vec = tensor[0];
+          } else {
+            vec = tensor;
+          }
         }
 
-        for (let row of results) {
-          const title = row.getResultByName("title");
-          const url = row.getResultByName("url");
-          const lastVisit = row.getResultByName("last_visit_date");
-          const relevanceScore = 1 - row.getResultByName("distance");
-          const previewImageURL = row.getResultByName("preview_image_url");
+        const vector = lazy.PlacesUtils.tensorToSQLBindable(vec);
+        let conn = await semanticManager.getConnection();
+        results = await conn.executeCached(
+          `
+          WITH coarse_matches AS (
+            SELECT rowid,
+                   embedding
+            FROM vec_history
+            WHERE embedding_coarse match vec_quantize_binary(:vector)
+            ORDER BY distance
+            LIMIT 100
+          ),
+          matches AS (
+            SELECT url_hash, vec_distance_cosine(embedding, :vector) AS distance
+            FROM vec_history_mapping
+            JOIN coarse_matches USING (rowid)
+            WHERE distance <= :distanceThreshold
+            ORDER BY distance
+            LIMIT :limit
+          )
+          SELECT id,
+                 title,
+                 url,
+                 distance,
+                 frecency,
+                 last_visit_date,
+                 preview_image_url
+          FROM moz_places
+          JOIN matches USING (url_hash)
+          WHERE frecency <> 0
+          AND (:start_ts IS NULL OR last_visit_date >= :start_ts)
+          AND (:end_ts IS NULL OR last_visit_date <= :end_ts)
+          ORDER BY distance
+          `,
+          {
+            vector: vector,
+            distanceThreshold: distanceThreshold,
+            limit: limit,
+            start_ts: start_ts,
+            end_ts: end_ts,
+          }
+        );
+      }
 
-          rows.push({
-            title: title || url,
-            url: url,
-            visitDate: new Date(Math.round(lastVisit / 1000)).toISOString(), // ISO timestamp format
-            visitCount: 0,
-            relevanceScore: relevanceScore || 0, // Use frecency as relevance score
-            ...(previewImageURL && { thumbnail: previewImageURL }), // Only include thumbnail if available
-          });
-        }
+      for (let row of results) {
+        const title = row.getResultByName("title");
+        const url = row.getResultByName("url");
+        const lastVisit = row.getResultByName("last_visit_date");
+        const relevanceScore = 1 - row.getResultByName("distance");
+        const previewImageURL = row.getResultByName("preview_image_url");
 
-        if (rows.length === 0) {
-          return JSON.stringify({
-            search_term,
-            results: [],
-            message: `No browser history found for "${search_term}".`,
-          });
-        }
+        rows.push({
+          title: title || url,
+          url: url,
+          visitDate: new Date(Math.round(lastVisit / 1000)).toISOString(), // ISO timestamp format
+          visitCount: 0,
+          relevanceScore: relevanceScore || 0, // Use frecency as relevance score
+          ...(previewImageURL && { thumbnail: previewImageURL }), // Only include thumbnail if available
+        });
+      }
 
-        // Return as JSON string with metadata
+      if (rows.length === 0) {
         return JSON.stringify({
           search_term,
-          count: rows.length,
-          results: rows,
+          results: [],
+          message: `No browser history found for "${search_term}".`,
         });
+      }
+
+      // Return as JSON string with metadata
+      return JSON.stringify({
+        search_term,
+        count: rows.length,
+        results: rows,
+      });
 
     }
 
@@ -333,9 +335,7 @@ export async function searchBrowserHistory({ search_term = "", start_ts = null, 
       results: [],
     });
   } finally {
-    if (root && openedRoot) {
-      root.containerOpen = false;
-    }
+
   }
 }
 


### PR DESCRIPTION
This PR updates the current history search to semantic search with temporal awareness.
@zhangyilun  @flozia @Mardak 

## Changes
- Replace the current logic for `searchBrowserHistory` function to temporal semantic search.
- Add `start_ts` and `end_ts` to the tool call config.
- Add timestamp information in system prompt.

## Notes
- **Semantic logic**
  - The semantic retrieval code similar to the classic mode ([ref1](https://searchfox.org/firefox-main/source/toolkit/components/places/PlacesSemanticHistoryManager.sys.mjs#849), [ref2](https://searchfox.org/firefox-main/source/toolkit/components/places/PlacesSemanticHistoryManager.sys.mjs#763))
  - Duplication exists because the original version hard code return size to 2.
- **Retrieval flow**
  - If `search_term` is empty → query `moz_places` directly within a time range.
  - If `search_term` exists → do a two-stage search:
    - coarse search (limit 100)
    - cosine similarity search (top 10, distance ≤ threshold).
  - thumbnail selection: change to `preview_image_url` from `moz_places`
- **Current issues / observations**
  - **Qwen model**
    - follow up similar queries don’t trigger the tool call.(e.g. ask "show me mario games I visited today" then "show me ninja games I visited today", first query get tool calls but second one doesn't)
    - timestamp parsing sometimes wrong ("last week" → 2024), adding current timestamp information in system prompt seem work so far, need to do more testing.
    - "last week" / "last month" behave as rolling 7/30 days, seems it's the correct behavior.
    - may have missing history, due to missing titles/descriptions in history record, as semantic history vec DB only contain history records that have titles/descriptions.
    - similarity threshold (0.6) and short `search_terms` may miss relevant pages. Will try to tune the function description to make the search_term more details.
    - `search_term` too short:  `search_term="ninja"` from "show me ninja games I visited today".
    - Sometimes popup old history result, need to do more testing to verify.
    - query "show my history" sometimes returns hallucination without calling the tool.
  - **GPT-5 model**
    - produces richer keyword lists but omits timestamps and is slower.
      - example: for query "show me ninja games i visited yesterday", `search_term` is "ninja games, shinobi, stealth ninja..." without time range.

## Open questions
1. **Thumbnail handling:**
    Should we use `preview_image_url` from `moz_places`, and fall back in this order: `preview_image_url` → `thumbnail` → `favicon?` ([ref1](https://searchfox.org/firefox-main/source/toolkit/components/places/History.sys.mjs#1635), [slack discussion about thumbnail](https://mozilla.slack.com/archives/C09GGG84NH3/p1762279355796119))
2. **Time range expansion:**
    Should parsed ranges be exact, or should we allow a small buffer, like +2 days?