### PR TITLE
add ALLOWED_OPENAI_PARAMS to openai pipeline

### DIFF
--- a/toolkit/components/ml/content/backends/OpenAIPipeline.mjs
+++ b/toolkit/components/ml/content/backends/OpenAIPipeline.mjs
@@ -26,6 +26,8 @@ let _logLevel = "Error";
  */
 const lazy = {};
 
+const DEFAULT_ALLOWED_OPENAI_PARAMS = Object.freeze(["tools", "tool_choice"]);
+
 ChromeUtils.defineLazyGetter(lazy, "console", () => {
   return console.createInstance({
     maxLogLevel: _logLevel, // we can't use maxLogLevelPref in workers.
@@ -68,6 +70,9 @@ export class OpenAIPipeline {
     let config = {};
     options.applyToConfig(config);
     config.backend = config.backend || "openai";
+    if (!config.allowedOpenAIParams) {
+      config.allowedOpenAIParams = DEFAULT_ALLOWED_OPENAI_PARAMS;
+    }
 
     // reapply logLevel if it has changed.
     if (lazy.console.logLevel != config.logLevel) {
@@ -334,6 +339,11 @@ export class OpenAIPipeline {
       });
       const stream = request.streamOptions?.enabled || false;
       const tools = request.tools || [];
+      const allowedOpenAIParams =
+        request.allowed_openai_params ??
+        request.allowedOpenAIParams ??
+        this.#options.allowedOpenAIParams ??
+        DEFAULT_ALLOWED_OPENAI_PARAMS;
 
       const completionParams = {
         model: modelId,
@@ -341,6 +351,13 @@ export class OpenAIPipeline {
         stream,
         tools,
       };
+
+      if (
+        Array.isArray(allowedOpenAIParams) &&
+        allowedOpenAIParams.length > 0
+      ) {
+        completionParams.allowed_openai_params = [...allowedOpenAIParams];
+      }
 
       const args = {
         client,


### PR DESCRIPTION
This pull request updates the `OpenAIPipeline` backend to introduce support for specifying allowed OpenAI parameters, improving configurability and control over API requests. The main changes include defining a default set of allowed parameters, updating configuration logic, and ensuring these parameters are properly passed in API requests.

Configuration and parameter management improvements:

* Defined a new constant `DEFAULT_ALLOWED_OPENAI_PARAMS` (containing `"tools"` and `"tool_choice"`) for use as the default allowed OpenAI parameters.
* Updated the pipeline configuration logic to set `allowedOpenAIParams` to the default value if not explicitly provided in the options.

API request handling enhancements:

* Modified request construction to resolve `allowedOpenAIParams` from multiple sources (request, options, or default) and ensure it is included in the completion parameters sent to the OpenAI API. [[1]](diffhunk://#diff-8fd22e5a16a79fd9f7b375c68d9963d4723b9a9357db6a906497a3fe1e5a7127R342-R346) [[2]](diffhunk://#diff-8fd22e5a16a79fd9f7b375c68d9963d4723b9a9357db6a906497a3fe1e5a7127R355-R361)add ALLOWED_OPENAI_PARAMS to openai pipeline