### PR TITLE
fix: chat history page_url and turn_index for messages

### DIFF
--- a/browser/base/content/browser-menubar.js
+++ b/browser/base/content/browser-menubar.js
@@ -336,16 +336,11 @@ function addRecentChatItems(menu, items, endMarker) {
         return;
       }
 
-      // TODO: Switch this from using conversation.pageUrl to getting the
-      // URL from the latest message with a pageUrl once per message page url
-      // tracking is added to the ChatHistory so that the chat opens to the
-      // page that the user was looking at last at the end of the conversation
-      if (
-        conversation?.pageUrl?.href &&
-        isValidUrl(conversation.pageUrl.href)
-      ) {
+      const lastVisitedSite = conversation.getMostRecentPageVisited();
+
+      if (lastVisitedSite && isValidUrl(lastVisitedSite)) {
         gBrowser.selectedTab = gBrowser.addTrustedTab(BROWSER_NEW_TAB_URL);
-        openUILink(conversation.pageUrl.href, event, {
+        openUILink(lastVisitedSite, event, {
           triggeringPrincipal:
             Services.scriptSecurityManager.createNullPrincipal({}),
         });

--- a/browser/components/smartwindow/ChatHistory.sys.mjs
+++ b/browser/components/smartwindow/ChatHistory.sys.mjs
@@ -460,17 +460,19 @@ export class ChatHistory {
         params: m.params ? JSON.stringify(m.params) : null,
         content: m.content,
         usage: m.usage ? JSON.stringify(m.usage) : null,
+        page_url: m.page_url?.href || "",
+        turn_index: m.turn_index,
       }));
       await this.#conn.executeCached(
         `
         INSERT INTO message (
           message_id, conv_id, created_date, parent_message_id,
           revision_root_message_id, ordinal, is_active_branch, role,
-          model_id, params_jsonb, content, usage_jsonb
+          model_id, params_jsonb, content, usage_jsonb, page_url, turn_index
         ) VALUES (
           :message_id, :conv_id, :created_date, :parent_message_id,
           :revision_root_message_id, :ordinal, :is_active_branch, :role,
-          :model_id, jsonb(:params), :content, jsonb(:usage)
+          :model_id, jsonb(:params), :content, jsonb(:usage), :page_url, :turn_index
         )
         ON CONFLICT(message_id) DO UPDATE SET
           is_active_branch = :is_active_branch
@@ -713,20 +715,25 @@ export class ChatHistoryConversation {
   /**
    * @param {ConversationRole} role - The type of conversation message
    * @param {string} content - The conversation message contents
+   * @param {string} page_url - The current page url when message was submitted
+   * @param {string} turn_index - The current conversation turn/cycle
    */
-  addMessage(role, content) {
+  addMessage(role, content, page_url, turn_index) {
     let parentMessageId = null;
     if (this?.messages?.length) {
       const lastMessageIndex = this.messages.length - 1;
       parentMessageId = this.messages[lastMessageIndex].id;
     }
 
-    const ordinal = this?.messages?.length ? this.messages.length + 1 : 1;
+    const currentMessages = this?.messages || [];
+    const ordinal = currentMessages.length ? currentMessages.length + 1 : 1;
 
     const newMessage = new ChatHistoryMessage({
       parentMessageId,
       content,
       ordinal,
+      page_url,
+      turn_index,
       role,
     });
 
@@ -735,16 +742,58 @@ export class ChatHistoryConversation {
 
   /**
    * @param {string} content - The user message content
+   * @param {string?} pageUrl - The current page url when message was submitted
+   * @param {number} [turn_index=0] - The conversation turn/cycle
    */
-  addUserMessage(content) {
-    this.addMessage(ChatHistory.MESSAGE_ROLE.USER, content);
+  addUserMessage(content, pageUrl = "", turn_index = 0) {
+    this.addMessage(
+      ChatHistory.MESSAGE_ROLE.USER,
+      content,
+      pageUrl,
+      turn_index
+    );
   }
 
   /**
    * @param {string} content - The assistant message content
+   * @param {*} turn_index - The current conversation turn/cycle
    */
-  addAssistantMessage(content) {
-    this.addMessage(ChatHistory.MESSAGE_ROLE.ASSISTANT, content);
+  addAssistantMessage(content, turn_index) {
+    this.addMessage(
+      ChatHistory.MESSAGE_ROLE.ASSISTANT,
+      content,
+      "",
+      turn_index
+    );
+  }
+
+  /**
+   * Retrieves the list of visited sites during a conversation in visited order.
+   *
+   * @returns {Array<string>} - Ordered list of visited page URLs for this conversation
+   */
+  getSitesList() {
+    const sites = new Set();
+
+    this.messages.forEach(message => {
+      if (message.page_url && isNotInternalUrl(message.page_url)) {
+        sites.add(message.page_url);
+      }
+    });
+
+    return Array.from(sites);
+  }
+
+  /**
+   * Returns the most recently visited site during this conversation, or null
+   * if no sites have been visited.
+   *
+   * @returns {string|null}
+   */
+  getMostRecentPageVisited() {
+    const sites = this.getSitesList();
+
+    return sites.length ? sites.pop() : null;
   }
 
   set messages(value) {
@@ -755,6 +804,25 @@ export class ChatHistoryConversation {
   get messages() {
     return this.#messages;
   }
+}
+
+// NOTE: This type of logic is used in several places, we should put
+// this somewhere to be reused instead of redeclared in multiple places
+function isNotInternalUrl(tabInfo) {
+  if (!tabInfo) {
+    return false;
+  }
+
+  const url = tabInfo.toLowerCase();
+
+  // Filter out browser internal URLs
+  return (
+    (!url.startsWith("about:") || url.startsWith("about:reader?")) &&
+    !url.startsWith("chrome:") &&
+    !url.startsWith("moz-extension:") &&
+    !url.startsWith("resource:") &&
+    url !== "about:blank"
+  );
 }
 
 /**

--- a/browser/components/smartwindow/content/chat.mjs
+++ b/browser/components/smartwindow/content/chat.mjs
@@ -1073,6 +1073,21 @@ class ChatBot extends MozLitElement {
     };
   }
 
+  getCurrentTabUrl(aUrl) {
+    // Get access to the browser window
+    const gBrowser = window?.browsingContext?.topChromeWindow?.gBrowser;
+    if (!gBrowser) {
+      return "";
+    }
+
+    const url = aUrl || gBrowser?.selectedBrowser?.currentURI?.spec;
+    try {
+      return new URL(url);
+    } catch (e) {
+      return "";
+    }
+  }
+
   async sendPrompt() {
     if (!this.prompt.trim()) {
       return;
@@ -1084,9 +1099,21 @@ class ChatBot extends MozLitElement {
       this.conversationTitle = "";
     }
 
+    const currentMessages = this.#conversation?.messages || [];
+    const turn_index =
+      currentMessages.reduce((turn, msg) => {
+        if (!isNaN(msg.turn_index) && msg.turn_index > turn) {
+          return msg.turn_index;
+        }
+
+        return turn;
+      }, -1) + 1;
+
+    const currentUrl = this.getCurrentTabUrl();
+
     // Conversation holds string-only {role, content}; keep render-only data in _uiMeta so it never reaches the backend.
     const before = this.#conversation.messages.length;
-    this.#conversation.addUserMessage(this.prompt);
+    this.#conversation.addUserMessage(this.prompt, currentUrl, turn_index);
     const msgsAfter = this.#conversation.messages;
     const userMsg = msgsAfter[before];
     const userKey = (userMsg && (userMsg.id ?? userMsg.messageId)) ?? before;
@@ -1147,7 +1174,7 @@ class ChatBot extends MozLitElement {
     }));
 
     // Prepare an empty assistant message for streaming
-    this.#conversation.addAssistantMessage("");
+    this.#conversation.addAssistantMessage("", turn_index);
     this.requestUpdate();
 
     const pageInfoMessage = this.#createPageInfoMessageIfNeeded();


### PR DESCRIPTION
- adds page_url to each user message in a conversation
- adds turn_index to each message in a conversation turn/cycle
- adds method to ChatHistoryConversation to retrieve ordered list of visited sites for a conversation
- adds method to retrieve the last site visited during a conversation
- updates the chat history retrieval to open the last site that a user visited during a conversation instead of the first site