### PR TITLE
Hiding entire smartwindow-box on DOMFullscreen

### DIFF
--- a/browser/themes/shared/tabbrowser/fullscreen-and-pointerlock.css
+++ b/browser/themes/shared/tabbrowser/fullscreen-and-pointerlock.css
@@ -8,6 +8,7 @@
 :root[inDOMFullscreen] #sidebar-main,
 :root[inDOMFullscreen] #sidebar-splitter,
 :root[inDOMFullscreen] #sidebar-launcher-splitter,
+:root[inDOMFullscreen] #smartwindow-box,
 :root[inFullscreen]:not([macOSNativeFullscreen]) toolbar:not([fullscreentoolbar="true"]) {
   visibility: collapse;
 }


### PR DESCRIPTION
Hiding Smart Window sidebar as per https://mozilla-hub.atlassian.net/browse/GENAI-2333

Following existing pattern of targeting entire component rather than specifically the Smart Window in 'sidebar' view