### PR TITLE
Showing Smart Window chat on History fullscreen

### DIFF
--- a/browser/components/smartwindow/content/page-history.mjs
+++ b/browser/components/smartwindow/content/page-history.mjs
@@ -184,8 +184,11 @@ export class PageHistoryOverlay extends LitElement {
 
   render() {
     if (!this.isOpen) {
+      document.documentElement.removeAttribute("smart-window-history");
       return html``;
     }
+
+    document.documentElement.setAttribute("smart-window-history", "true");
 
     return html`
       <div class="history-overlay" @click=${this.handleOverlayClick}>

--- a/browser/components/smartwindow/content/page-history.mjs
+++ b/browser/components/smartwindow/content/page-history.mjs
@@ -184,11 +184,8 @@ export class PageHistoryOverlay extends LitElement {
 
   render() {
     if (!this.isOpen) {
-      document.documentElement.removeAttribute("smart-window-history");
       return html``;
     }
-
-    document.documentElement.setAttribute("smart-window-history", "true");
 
     return html`
       <div class="history-overlay" @click=${this.handleOverlayClick}>

--- a/browser/themes/shared/browser-shared.css
+++ b/browser/themes/shared/browser-shared.css
@@ -1439,9 +1439,11 @@ browser {
   }
 }
 
-:root[smart-window][smart-window-url] #smartwindow-box,
-:root[smart-window][smart-window-url] #smartwindow-splitter {
-  visibility: collapse;
+:root[smart-window][smart-window-url]:not([inFullscreen]) {
+  #smartwindow-box,
+  #smartwindow-splitter {
+    visibility: collapse;
+  }
 }
 
 :root[smart-window] .tabbrowser-tab > .tab-stack > .tab-background[selected] {


### PR DESCRIPTION
Hooked new smart-window-history attr into render method to delineate History page, ensuring that Smart Window chat exists in History fullscreen